### PR TITLE
Remove Press enter to continue from tests

### DIFF
--- a/tests/test_nvmf_create_host.py
+++ b/tests/test_nvmf_create_host.py
@@ -68,4 +68,3 @@ class TestNVMFCreateHost(NVMFTest):
         print("Now Running " + self.__class__.__name__)
         ret = self.host_subsys.config(self.target_config_file)
         assert_equal(ret, True, "ERROR : host config failed")
-        raw_input("Press enter to continue ...")

--- a/tests/test_nvmf_create_pci_target.py
+++ b/tests/test_nvmf_create_pci_target.py
@@ -67,4 +67,3 @@ class TestNVMFCreatePCIeTarget(NVMFTest):
         print("Now Running " + self.__class__.__name__)
         ret = self.host_subsys.config(self.target_config_file)
         assert_equal(ret, True, "ERROR : host config failed")
-        raw_input("Press enter to continue ...")


### PR DESCRIPTION
When executing test_nvmf_create_host.py or
test_nvmf_create_pci_target.py, the tests waited for pressing of enter
key. However, when running automated tests, this is not feasible.
The raw_input()-calls to wait for pressing of enter could simply be
removed.